### PR TITLE
Add utilities directory and an excerpt utility 

### DIFF
--- a/cms-react-utilities/createExcerpt.ts
+++ b/cms-react-utilities/createExcerpt.ts
@@ -1,0 +1,12 @@
+export function stripHtmlTags(stringWithTags: string): string {
+  return stringWithTags.replace(/<\/?[^>]+>/gi, '');
+}
+
+export function createExcerpt(excerptString: string, maxLength: number): string {
+  const excerptWithoutTags = stripHtmlTags(excerptString);
+  const showEllipsis = excerptWithoutTags.length > maxLength;
+
+  return showEllipsis
+    ? `${excerptWithoutTags.substring(0, maxLength)}...`
+    : excerptWithoutTags;
+}


### PR DESCRIPTION
### Description
[This is part of the EPIC](https://git.hubteam.com/HubSpot/content-assets/issues/870) to ensure that we provide utilities to the public instances of our default modules. I added the `createExcerpt` from the BlogPosts module as a starter example, as I can work out applying it to the internal and external module and confirm it works as expected. 

I have an audit issue underway to as well, reviewing all existing HubL functions and filters which will help expand this directory.