### PR TITLE
Fix typo in fields type gen doc

### DIFF
--- a/docs/reference/cms-dev-server.md
+++ b/docs/reference/cms-dev-server.md
@@ -85,7 +85,7 @@ Storybook is built with client components in mind, so components that cross isla
 
 ## Fields Type Generation
 
-If you are using Typescript in your CMS React project, you can make use of the `--generateFieldTypes` argument of the dev server. This command will watch for changes to the fields object that is exported from module file and create a `.types.ts` file inside of the directory of the module. You can then import this module directly into your module component and use it in the generic `ModuleProps<T>` type. As an example, if this is your `fields.jsx` file:
+If you are using Typescript in your CMS React project, you can make use of the `--generateFieldsTypes` argument of the dev server. This command will watch for changes to the fields object that is exported from module file and create a `.types.ts` file inside of the directory of the module. You can then import this module directly into your module component and use it in the generic `ModuleProps<T>` type. As an example, if this is your `fields.jsx` file:
 
 ```tsx
 // components/modules/MyModule/fields.tsx


### PR DESCRIPTION
`generateFieldTypes` => `generateFieldsTypes`
https://hubspotdev.slack.com/archives/C04AY1H2204/p1715978534323979