### PR TITLE
Add link to developer slack sign up in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Check out an expanded documentation page at [https://github.hubspot.com/cms-reac
 
 ## Welcome!
 
-Thank you for taking the time to learn about HubSpot CMS React. As always our goal is to solve for our customers so we welcome any and all feedback. Chat away in [\#cms-react](https://hubspotdev.slack.com/archives/C04AY1H2204) with other HubSpot developers who are pushing forward with developing with React on the Hubspot CMS.
+Thank you for taking the time to learn about HubSpot CMS React. As always our goal is to solve for our customers so we welcome any and all feedback. Chat away in [\#cms-react](https://hubspotdev.slack.com/archives/C04AY1H2204) with other HubSpot developers who are pushing forward with developing with React on the Hubspot CMS. If you do not have access to the developer slack, you can request access [here](https://developers.hubspot.com/slack).
 
 ## How do React modules on the CMS work?
 


### PR DESCRIPTION
Resolves https://github.com/HubSpot/cms-react/issues/57

We mention our `cms-react` slack channel in the README, but for new devs coming to HubSpot they may not have access to the greater developer slack group.