### PR TITLE
Improve getSecret documentation

### DIFF
--- a/docs/reference/cms-components.md
+++ b/docs/reference/cms-components.md
@@ -20,7 +20,11 @@ Returns `true` for components rendered live for a deployed project and `false` w
 
 `(secretName: string) => string`
 
-Returns a value for a given secret key. The secret must be defined using `hs secrets` in the CLI and the key must be included in a `secretNames` array in your `cms-assets.json` configuration. To prevent accidentally leaking secrets, `getSecret()` can only be called from components executed on the server and not from the browser (i.e. within an island).
+Returns a value for a given secret key. The secret must be defined using `hs secrets` in the CLI and the key must be included in a `secretNames` array in your `cms-assets.json` configuration. To prevent accidentally leaking secrets, `getSecret()`:
+  - **Cannot** be called at the top-level of a module
+  - **Cannot** be called from inside an island
+
+In other words, `getSecert` _must be called from_ a React component function that is rendered on the server. And if you want to pass a secret to client-side code—which makes it available public "view-source" viewing—you must explicitly pass the secret string via an island prop.
 
 See the [Secrets section](./secrets) for more information on usage.
 

--- a/docs/reference/secrets.md
+++ b/docs/reference/secrets.md
@@ -4,7 +4,7 @@ CMS React components integrate with the same secrets store used by [HubSpot serv
 
 To start using secrets, store secret values using `hs secrets add` in the HubSpot CLI, then add the names of secrets used by your components to a `secretNames` array in your `cms-assets.json` config. For example:
 
-```json
+```js
 // cms-assets.json
 {
   "label": "My CMS project",
@@ -12,14 +12,22 @@ To start using secrets, store secret values using `hs secrets add` in the HubSpo
 }
 ```
 
-To access the secret, `@hubspot/cms-components` exports a `getSecret()` function to return a given secret's value. To prevent accidentally leaking  secrets, `getSecret()` can only be called from components executed on the server and not from the browser (i.e. within an island). If a secret value isn't sensitive and you need to access it in island components, you may call `getSecret()` outside the island and pass the value down via a prop.
+To access the secret, `@hubspot/cms-components` exports a `getSecret()` function to return a given secret's value. To prevent accidentally leaking  secrets, `getSecret()` can only be called from component code executed on the server and not from the browser (i.e. within an island). If a secret value isn't sensitive and you need to access it in island components, you may call `getSecret()` outside the island and pass the value down via a prop.
+
 ```javascript
 import { getSecret } from '@hubspot/cms-components';
 
 // ...
 
 // in a React component outside of an island
-const mySecretValue = getSecret('TEST_SECRET');
+export function Component(props) {
+  const mySecretValue = getSecret('TEST_SECRET');
+
+  return <OtherComponent secret={mySecretValue} >;
+};
+
+// Note, this code will fail since it is not called from within a component's render function (or from a utiliity function called from the component's render function)
+// const SECRET_NO_WORK = getSecret('secrets-dont-work-at-module-top-level');
 ```
 
 ## Secrets in local development

--- a/docs/reference/secrets.md
+++ b/docs/reference/secrets.md
@@ -16,7 +16,6 @@ To access the secret, `@hubspot/cms-components` exports a `getSecret()` function
 
 ```javascript
 import { getSecret } from '@hubspot/cms-components';
-
 // ...
 
 // in a React component outside of an island


### PR DESCRIPTION
... to make it more clear that you cannot call `getSecret` from the top-level of a module.