### PR TITLE
move getting started templates to a templates folder

### DIFF
--- a/examples/getting-started-project-theme/src/getting-started-theme/templates/layouts/base.hubl.html
+++ b/examples/getting-started-project-theme/src/getting-started-theme/templates/layouts/base.hubl.html
@@ -17,7 +17,7 @@
   <body>
     <div class="body-wrapper {{ builtin_body_classes }}">
       {% block header %}
-        {% module 'main header' path="@projects/getting-started-project-theme/getting-started-theme/components/modules/Header" %}
+        {% module 'main header' path="../../components/modules/Header" %}
       {% endblock header %}
 
       {# The main-content ID is used for the navigation skipper in the header.html file. More information on the navigation skipper can be found here: https://github.com/HubSpot/cms-theme-boilerplate/wiki/Accessibility #}
@@ -26,7 +26,7 @@
       {% endblock body %}
 
       {% block footer %}
-        {% module 'footer' path="@projects/getting-started-project-theme/getting-started-theme/components/modules/Footer" %}
+        {% module 'footer' path="../../components/modules/Footer" %}
       {% endblock footer %}
     </div>
 

--- a/examples/getting-started-project-theme/src/getting-started-theme/templates/weather.hubl.html
+++ b/examples/getting-started-project-theme/src/getting-started-theme/templates/weather.hubl.html
@@ -9,7 +9,7 @@
 
   {% module
     "weather"
-    path="@projects/getting-started-project-theme/getting-started-theme/components/modules/Weather",
+    path="../components/modules/Weather",
   %}
 
 {% endblock body %}


### PR DESCRIPTION
Relative paths make the getting-started theme easier to use as a starting point with a new project name. Also keeping templates in a /templates/ folder makes the theme look more like a traditional hubl theme, which should make setup a bit easier