### PR TITLE
Islands typescript fix

### DIFF
--- a/examples/islands/.eslintrc.js
+++ b/examples/islands/.eslintrc.js
@@ -1,4 +1,6 @@
 module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     sourceType: 'module',
     ecmaFeatures: {
@@ -9,7 +11,13 @@ module.exports = {
     node: true,
     es2021: true,
   },
-  extends: ['eslint:recommended', 'prettier', 'plugin:react/recommended'],
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'prettier',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
   rules: {
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',

--- a/examples/islands/islands-project/islands-app/Globals.d.ts
+++ b/examples/islands/islands-project/islands-app/Globals.d.ts
@@ -1,1 +1,12 @@
 declare module '*.module.css';
+
+// copied directly from @hubspot/cms-components
+declare module '*?island' {
+  const lazyComponent: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (): Promise<{ default: React.ComponentType<any> }>;
+    moduleName: string;
+    moduleId: string;
+  };
+  export default lazyComponent;
+}

--- a/examples/islands/islands-project/islands-app/components/partials/IslandsTester.tsx
+++ b/examples/islands/islands-project/islands-app/components/partials/IslandsTester.tsx
@@ -2,20 +2,18 @@ import { Island } from '@hubspot/cms-components';
 
 import ButtonCounterIsland from '../ButtonCounter?island';
 
-const IslandsTester = ({
+export default function IslandsTester({
   numIslands = 1,
   marginTop,
   marginBetween = '50vh',
   hydrateOn = 'load',
   islandIdPrefix = '',
-}) => {
-  numIslands = parseInt(numIslands, 10);
-
-  const islandElements = new Array(numIslands).fill('').map((_, i) => {
-    let style = { marginTop: marginTop ?? marginBetween };
-    if (i === 0 && marginTop == null) {
-      delete style.marginTop;
-    }
+}: Props) {
+  const islandElements = Array.from({ length: Number(numIslands) }, (_, i) => {
+    const style =
+      i === 0 && marginTop == null
+        ? null
+        : { marginTop: marginTop ?? marginBetween };
 
     const islandId = `${islandIdPrefix}island-${i}`;
 
@@ -30,7 +28,14 @@ const IslandsTester = ({
       />
     );
   });
-  return <div style={{ fontSize: '1.5em' }}>{islandElements}</div>;
-};
 
-export default IslandsTester;
+  return <div style={{ fontSize: '1.5em' }}>{islandElements}</div>;
+}
+
+interface Props {
+  numIslands?: number | string;
+  marginTop?: string | null;
+  marginBetween?: string;
+  hydrateOn?: string;
+  islandIdPrefix?: string;
+}

--- a/examples/islands/islands-project/islands-app/tsconfig.json
+++ b/examples/islands/islands-project/islands-app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "module": "commonjs",
+    "module": "Node16",
     "moduleResolution": "node16",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/islands/package.json
+++ b/examples/islands/package.json
@@ -5,16 +5,19 @@
   "devDependencies": {
     "@hubspot/cli": "latest",
     "@hubspot/prettier-plugin-hubl": "latest",
+    "@typescript-eslint/eslint-plugin": "^8.31.1",
+    "@typescript-eslint/parser": "^8.31.1",
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.31.10",
     "prettier": "^2.7.1",
+    "typescript": "^5.8.3",
     "yarpm": "^1.2.0"
   },
   "scripts": {
     "start": "cd islands-project/islands-app && yarpm start --",
     "postinstall": "cd islands-project/islands-app && yarpm install",
-    "lint:js": "eslint . --ext .js,.jsx",
+    "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
     "prettier": "prettier . --check",
     "watch:hubl": "hs watch islands-theme islands-theme",
     "upload:hubl": "hs upload islands-theme islands-theme",


### PR DESCRIPTION
## Summary

- fix `"module"` setting error in typescript configuration
- make eslint recognize and lint typescript files
  - fixes inline eslint errors that appear in-editor
- copy over global island import declaration from `@hubspot/cms-components`
- convert one of the `.jsx` partials to `.tsx` to provide working example
  - added prop types to clean up errors
  - use `Number` instead of `parseInt` because `parseInt` doesn't like `number` for its first argument
  - modernize array creation/fill

Happy to make changes or break this up as requested. It's mostly fixing hurdles I've been hitting trying to set up a CMS React project using TS.